### PR TITLE
Mutation tests finally work well

### DIFF
--- a/bitz/pom.xml
+++ b/bitz/pom.xml
@@ -42,6 +42,16 @@
                     <jvmArgs>
                         <value>-Djava.library.path=${project.basedir}/target/natives</value>
                     </jvmArgs>
+                    <targetClasses>
+                        <param>bitzgame.bitz.*</param>
+                    </targetClasses>
+                    <excludedClasses>
+                        <param>bitzgame.bitz.Main</param>
+                    </excludedClasses>
+                    <targetTests>
+                        <param>bitzgame.bitz.*</param>
+                    </targetTests>
+                    <threads>1</threads>
                 </configuration>
             </plugin>
             <plugin>

--- a/bitz/src/test/java/bitzgame/bitz/GameObjectTest.java
+++ b/bitz/src/test/java/bitzgame/bitz/GameObjectTest.java
@@ -1,0 +1,139 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package bitzgame.bitz;
+
+import java.util.ArrayList;
+
+import org.junit.Test;
+import static org.junit.Assert.*;
+import org.junit.Before;
+import org.newdawn.slick.Input;
+import org.newdawn.slick.SlickException;
+//import org.newdawn.slick.Input;
+
+/**
+ *
+ * @author Timo
+ */
+
+public class GameObjectTest {
+
+    public GameObjectTest() {
+    }
+    
+    GameTestCtx gameLoop;
+
+    @Before
+    public void setUp() throws SlickException {
+        gameLoop = GameTestCtx.setup();
+    }
+
+    @Test
+    public void gameObjectRenderableTest1() throws InterruptedException {
+        
+        Throwable result = gameLoop.runInLoop(() -> {
+            try {
+                GameObject g = new GameObject(0,0);
+                Camera c = new Camera(0,0);
+                if(!g.renderable(c)){
+                    throw new Exception();
+                } 
+                return new OkResult();
+            } catch (Exception e) {
+                return e;
+            }
+        });
+        
+        assertEquals("Did it work?", new OkResult(), result);
+    }
+    @Test
+    public void gameObjectRenderableTest2() throws InterruptedException {
+        
+        Throwable result = gameLoop.runInLoop(() -> {
+            try {
+                GameObject g = new GameObject(0,0);
+                Camera c = null;
+                if(g.renderable(c)){
+                    return new ErrMsg("Object shouldn't be renderable with a Camera that is null!");
+                } 
+                return new OkResult();
+            } catch (Exception e) {
+                return e;
+            }
+        });
+        
+        assertEquals("Did it work?", new OkResult(), result);
+    }
+    
+    @Test
+    public void gameObjectCollidesWithTest() throws InterruptedException {
+        Throwable result = gameLoop.runInLoop(() -> {
+            try {
+                GameObject g = new GameObject(0,0);
+                GameObject gg = new GameObject(1,1);
+                if(g.collidesWith(gg)){
+                    return new OkResult();
+                } else {
+                    return new ErrMsg("Doesnt collide");
+                }
+            } catch (Exception e) {
+                return e;
+            }
+        });
+        
+        assertEquals("Did it work?", new OkResult(), result);
+    }
+    
+    @Test
+    public void gameObjectCollidesAnyTest() throws InterruptedException {
+        
+        Throwable result = gameLoop.runInLoop(() -> {
+            try {
+                GameObject g = new GameObject(0,0);
+                GameObject gg = new GameObject(1,1);
+                Projectile p = new Projectile(15,15,"src/assets/spr_item_crest.png",3);
+                ArrayList<GameObject> list = new ArrayList<GameObject>();
+                list.add(gg);
+                list.add(p);
+                if(g.collidesAny(list)!=null){
+                    return new OkResult();
+                } else {
+                    return new ErrMsg("Doesn't collide with anything");
+                }
+            } catch (Exception e) {
+                return e;
+            }
+        });
+        
+        assertEquals("Did it work?", new OkResult(), result);
+    }
+    
+    @Test
+    public void playerShootTest() throws InterruptedException {
+        
+        Throwable result = gameLoop.runInLoop(() -> {
+            try {
+                Input i = new Input(480);
+                Player p = new Player(0,0,"src/assets/spr_item_crest.png",5,i);
+                p.setTryShoot(true);
+                if (p.shoot(2) != null) {
+                    return new OkResult();
+                } else {
+                    return new ErrMsg("Nothing shot");
+                }
+                
+            } catch (Exception e) {
+                return e;
+            }
+        });
+        
+        assertEquals("Did it work?", new OkResult(), result);
+    }
+    
+    
+    
+
+}

--- a/bitz/src/test/java/bitzgame/bitz/GameObjectTest.java
+++ b/bitz/src/test/java/bitzgame/bitz/GameObjectTest.java
@@ -18,12 +18,11 @@ import org.newdawn.slick.SlickException;
  *
  * @author Timo
  */
-
 public class GameObjectTest {
 
     public GameObjectTest() {
     }
-    
+
     GameTestCtx gameLoop;
 
     @Before
@@ -33,107 +32,84 @@ public class GameObjectTest {
 
     @Test
     public void gameObjectRenderableTest1() throws InterruptedException {
-        
+
         Throwable result = gameLoop.runInLoop(() -> {
-            try {
-                GameObject g = new GameObject(0,0);
-                Camera c = new Camera(0,0);
-                if(!g.renderable(c)){
-                    throw new Exception();
-                } 
-                return new OkResult();
-            } catch (Exception e) {
-                return e;
+            GameObject g = new GameObject(0, 0);
+            Camera c = new Camera(0, 0);
+            if (!g.renderable(c)) {
+                throw new Exception();
             }
+            return new OkResult();
         });
-        
+
         assertEquals("Did it work?", new OkResult(), result);
     }
+
     @Test
     public void gameObjectRenderableTest2() throws InterruptedException {
-        
+
         Throwable result = gameLoop.runInLoop(() -> {
-            try {
-                GameObject g = new GameObject(0,0);
-                Camera c = null;
-                if(g.renderable(c)){
-                    return new ErrMsg("Object shouldn't be renderable with a Camera that is null!");
-                } 
-                return new OkResult();
-            } catch (Exception e) {
-                return e;
+            GameObject g = new GameObject(0, 0);
+            Camera c = null;
+            if (g.renderable(c)) {
+                return new ErrMsg("Object shouldn't be renderable with a Camera that is null!");
             }
+            return new OkResult();
         });
-        
+
         assertEquals("Did it work?", new OkResult(), result);
     }
-    
+
     @Test
     public void gameObjectCollidesWithTest() throws InterruptedException {
         Throwable result = gameLoop.runInLoop(() -> {
-            try {
-                GameObject g = new GameObject(0,0);
-                GameObject gg = new GameObject(1,1);
-                if(g.collidesWith(gg)){
-                    return new OkResult();
-                } else {
-                    return new ErrMsg("Doesnt collide");
-                }
-            } catch (Exception e) {
-                return e;
+            GameObject g = new GameObject(0, 0);
+            GameObject gg = new GameObject(1, 1);
+            if (g.collidesWith(gg)) {
+                return new OkResult();
+            } else {
+                return new ErrMsg("Doesnt collide");
             }
         });
-        
+
         assertEquals("Did it work?", new OkResult(), result);
     }
-    
+
     @Test
     public void gameObjectCollidesAnyTest() throws InterruptedException {
-        
+
         Throwable result = gameLoop.runInLoop(() -> {
-            try {
-                GameObject g = new GameObject(0,0);
-                GameObject gg = new GameObject(1,1);
-                Projectile p = new Projectile(15,15,"src/assets/spr_item_crest.png",3);
-                ArrayList<GameObject> list = new ArrayList<GameObject>();
-                list.add(gg);
-                list.add(p);
-                if(g.collidesAny(list)!=null){
-                    return new OkResult();
-                } else {
-                    return new ErrMsg("Doesn't collide with anything");
-                }
-            } catch (Exception e) {
-                return e;
+            GameObject g = new GameObject(0, 0);
+            GameObject gg = new GameObject(1, 1);
+            Projectile p = new Projectile(15, 15, "src/assets/spr_item_crest.png", 3);
+            ArrayList<GameObject> list = new ArrayList<>();
+            list.add(gg);
+            list.add(p);
+            if (g.collidesAny(list) != null) {
+                return new OkResult();
+            } else {
+                return new ErrMsg("Doesn't collide with anything");
             }
         });
-        
+
         assertEquals("Did it work?", new OkResult(), result);
     }
-    
+
     @Test
     public void playerShootTest() throws InterruptedException {
-        
+
         Throwable result = gameLoop.runInLoop(() -> {
-            try {
-                Input i = new Input(480);
-                Player p = new Player(0,0,"src/assets/spr_item_crest.png",5,i);
-                p.setTryShoot(true);
-                if (p.shoot(2) != null) {
-                    return new OkResult();
-                } else {
-                    return new ErrMsg("Nothing shot");
-                }
-                
-            } catch (Exception e) {
-                return e;
+            Input i = new Input(480);
+            Player p = new Player(0, 0, "src/assets/spr_item_crest.png", 5, i);
+            p.setTryShoot(true);
+            if (p.shoot(2) != null) {
+                return new OkResult();
+            } else {
+                return new ErrMsg("Nothing shot");
             }
         });
-        
+
         assertEquals("Did it work?", new OkResult(), result);
     }
-    
-    
-    
 
 }

--- a/bitz/src/test/java/bitzgame/bitz/GameObjectTest.java
+++ b/bitz/src/test/java/bitzgame/bitz/GameObjectTest.java
@@ -31,52 +31,48 @@ public class GameObjectTest {
     }
 
     @Test
-    public void gameObjectRenderableTest1() throws InterruptedException {
+    public void gameObjectRenderableTest1() {
 
         Throwable result = gameLoop.runInLoop(() -> {
             GameObject g = new GameObject(0, 0);
             Camera c = new Camera(0, 0);
             if (!g.renderable(c)) {
-                throw new Exception();
+                throw new ErrMsg("");
             }
-            return new OkResult();
         });
 
-        assertEquals("Did it work?", new OkResult(), result);
+        assertEquals("Did it work?", gameLoop.ok, result);
     }
 
     @Test
-    public void gameObjectRenderableTest2() throws InterruptedException {
+    public void gameObjectRenderableTest2() {
 
         Throwable result = gameLoop.runInLoop(() -> {
             GameObject g = new GameObject(0, 0);
             Camera c = null;
             if (g.renderable(c)) {
-                return new ErrMsg("Object shouldn't be renderable with a Camera that is null!");
+                throw new ErrMsg("Object shouldn't be renderable with a Camera that is null!");
             }
-            return new OkResult();
         });
 
-        assertEquals("Did it work?", new OkResult(), result);
+        assertEquals("Did it work?", gameLoop.ok, result);
     }
 
     @Test
-    public void gameObjectCollidesWithTest() throws InterruptedException {
+    public void gameObjectCollidesWithTest() {
         Throwable result = gameLoop.runInLoop(() -> {
             GameObject g = new GameObject(0, 0);
             GameObject gg = new GameObject(1, 1);
             if (g.collidesWith(gg)) {
-                return new OkResult();
-            } else {
-                return new ErrMsg("Doesnt collide");
+                throw new ErrMsg("Doesnt collide");
             }
         });
 
-        assertEquals("Did it work?", new OkResult(), result);
+        assertEquals("Did it work?", gameLoop.ok, result);
     }
 
     @Test
-    public void gameObjectCollidesAnyTest() throws InterruptedException {
+    public void gameObjectCollidesAnyTest() {
 
         Throwable result = gameLoop.runInLoop(() -> {
             GameObject g = new GameObject(0, 0);
@@ -85,31 +81,27 @@ public class GameObjectTest {
             ArrayList<GameObject> list = new ArrayList<>();
             list.add(gg);
             list.add(p);
-            if (g.collidesAny(list) != null) {
-                return new OkResult();
-            } else {
-                return new ErrMsg("Doesn't collide with anything");
+            if (g.collidesAny(list) == null) {
+                throw new ErrMsg("Doesn't collide with anything");
             }
         });
 
-        assertEquals("Did it work?", new OkResult(), result);
+        assertEquals("Did it work?", gameLoop.ok, result);
     }
 
     @Test
-    public void playerShootTest() throws InterruptedException {
+    public void playerShootTest() {
 
         Throwable result = gameLoop.runInLoop(() -> {
             Input i = new Input(480);
             Player p = new Player(0, 0, "src/assets/spr_item_crest.png", 5, i);
             p.setTryShoot(true);
-            if (p.shoot(2) != null) {
-                return new OkResult();
-            } else {
-                return new ErrMsg("Nothing shot");
+            if (p.shoot(2) == null) {
+                throw new ErrMsg("Nothing shot");
             }
         });
 
-        assertEquals("Did it work?", new OkResult(), result);
+        assertEquals("Did it work?", gameLoop.ok, result);
     }
 
 }

--- a/bitz/src/test/java/bitzgame/bitz/GameTestCtx.java
+++ b/bitz/src/test/java/bitzgame/bitz/GameTestCtx.java
@@ -19,10 +19,19 @@ import org.newdawn.slick.SlickException;
  * @author Pyry Kontio
 */
 
+// A stateless class for signaling the "no errors or exceptions" case.
+// Meant to be used as a singleton. 
 class OkResult extends Throwable {
-    
+    @Override
+    public boolean equals(Object o) {
+        return o instanceof OkResult;
+    }
+
+    @Override
+    public int hashCode() { return 0; }
 }
 
+// A class for returning an error message to signal error cases in the tests.
 class ErrMsg extends Throwable {
     String errmsg;
     ErrMsg(String e){
@@ -31,14 +40,18 @@ class ErrMsg extends Throwable {
 }
 
 class GameTestCtx extends BasicGame implements Runnable {
+    
+    public static GameTestCtx theOneContext; // Unfortunately there can be only
+                                             // one per process, due to the limitations of Slick2D
+    private final AppGameContainer container;
+    private final BlockingQueue<Supplier<Throwable>> inputQueue;
+    private final BlockingQueue<Throwable> returnQueue;
 
-    static AppGameContainer container;
-    static BlockingQueue<Supplier<Throwable>> inputQueue;
-    static BlockingQueue<Throwable> returnQueue;
-    static OkResult ok;
-
-    public GameTestCtx(String title) {
+    public GameTestCtx(String title) throws SlickException {
         super(title);
+            container = new AppGameContainer(this);
+            inputQueue = new ArrayBlockingQueue<>(1);
+            returnQueue = new ArrayBlockingQueue<>(1);
     }
 
     @Override
@@ -47,17 +60,16 @@ class GameTestCtx extends BasicGame implements Runnable {
 
     @Override
     public void update(GameContainer gc, int i) throws SlickException {
+        System.out.println("GameTestCtx.update: Start a new frame.");
         Supplier<Throwable> test;
         try {
-            System.out.println("UPDATE 1");
             test = inputQueue.take();
-            System.out.println("UPDATE 2 taken");
             Throwable result = test.get();
-            System.out.println("UPDATE 3 test ran");
             returnQueue.put(result);
-            System.out.println("UPDATE 4 put");
-        } catch (InterruptedException ex) {}
-
+        } catch (InterruptedException ex) {
+            System.out.println("Update method: Exception: " + ex);
+        }
+        System.out.println("GameTestCtx.update: One test successfully run.");
     }
 
     @Override
@@ -67,18 +79,31 @@ class GameTestCtx extends BasicGame implements Runnable {
     @Override
     public void run() {
         try {
-            container = new AppGameContainer(this);
             container.setDisplayMode(640, 480, false);
             container.start();
 
         } catch (SlickException ex) {
+            
         }
     }
 
-    public static void setup() {
-        GameTestCtx.ok = new OkResult();
-        GameTestCtx.inputQueue = new ArrayBlockingQueue<Supplier<Throwable>>(1);
-        GameTestCtx.returnQueue = new ArrayBlockingQueue<Throwable>(1);
-        (new Thread(new GameTestCtx("TestCtx"))).start();
+    public static GameTestCtx setup() throws SlickException {
+        if (theOneContext == null) {
+            theOneContext = new GameTestCtx("TestCtx");
+            Thread t = new Thread(theOneContext);
+            t.start();
+            System.out.println("Initialized the Game Test Context.");
+        }
+        return theOneContext;
+    }
+    
+    public Throwable runInLoop(Supplier<Throwable> test) {
+        try {
+            inputQueue.put(test);
+            return returnQueue.take();
+        } catch (Exception e) {
+            System.out.println("runInLoop method: Error while sending the test to another thread: " + e);
+            return null;
+        }
     }
 }

--- a/bitz/src/test/java/bitzgame/bitz/MainTest.java
+++ b/bitz/src/test/java/bitzgame/bitz/MainTest.java
@@ -38,12 +38,8 @@ public class MainTest {
     @Test
     public void imageTest() {
         Throwable result = gameLoop.runInLoop(() -> {
-            try {
-                Image test = new Image("src/assets/spr_item_crest.png");
-                return new OkResult();
-            } catch (Exception e) {
-                return e;
-            }
+            Image test = new Image("src/assets/spr_item_crest.png");
+            return new OkResult();
         });
         assertEquals("Did it work?", new OkResult(), result);
     }

--- a/bitz/src/test/java/bitzgame/bitz/MainTest.java
+++ b/bitz/src/test/java/bitzgame/bitz/MainTest.java
@@ -5,16 +5,12 @@
  */
 package bitzgame.bitz;
 
-import java.util.ArrayList;
-import java.util.concurrent.ArrayBlockingQueue;
-import java.util.function.Supplier;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
+
 import org.junit.Test;
 import static org.junit.Assert.*;
+import org.junit.Before;
 import org.newdawn.slick.Image;
+import org.newdawn.slick.SlickException;
 //import org.newdawn.slick.Input;
 
 /**
@@ -26,131 +22,29 @@ public class MainTest {
 
     public MainTest() {
     }
-
-    @BeforeClass
-    public static void setUpClass() {
-        GameTestCtx.setup();
-    }
-
-    @AfterClass
-    public static void tearDownClass() {
-    }
+    
+    // Unfortunately it seems that Slick2D supports only one game window per process.
+    // This means that this field can be static as well.
+    GameTestCtx gameLoop;
 
     @Before
-    public void setUp() {
-    }
-
-    @After
-    public void tearDown() {
+    public void setUp() throws SlickException {
+        gameLoop = GameTestCtx.setup();
     }
 
     /**
      * Test of main method, of class Main.
      */
     @Test
-    public void imageTest() throws InterruptedException {
-        // NOTE to Timo: Do NOT use assertions inside the () -> { test }! Only catch errors and return them.
-        GameTestCtx.inputQueue.put(() -> {
+    public void imageTest() {
+        Throwable result = gameLoop.runInLoop(() -> {
             try {
                 Image test = new Image("src/assets/spr_item_crest.png");
-                if (test == null) {
-                    throw new Exception();
-                }
-                return GameTestCtx.ok;
+                return new OkResult();
             } catch (Exception e) {
                 return e;
             }
         });
-        Throwable ex = GameTestCtx.returnQueue.take();
-        assertEquals("Did it work?", ex, GameTestCtx.ok);
+        assertEquals("Did it work?", new OkResult(), result);
     }
-    /*
-    @Test
-    public void gameObjectRenderableTest1() throws InterruptedException {
-        // NOTE to Timo: Do NOT use assertions inside the () -> { test }! Only catch errors and return them.
-        GameTestCtx.inputQueue.put(() -> {
-            try {
-                GameObject g = new GameObject(0,0);
-                Camera c = new Camera(0,0);
-                if(!g.renderable(c)){
-                    throw new Exception();
-                } 
-                return GameTestCtx.ok;
-            } catch (Exception e) {
-                return e;
-            }
-        });
-        Throwable ex = GameTestCtx.returnQueue.take();
-        assertEquals("Did it work?", ex, GameTestCtx.ok);
-    }*/
-    
-    /*@Test
-    public void gameObjectCollidesWithTest() throws InterruptedException {
-        // NOTE to Timo: Do NOT use assertions inside the () -> { test }! Only catch errors and return them.
-        GameTestCtx.inputQueue.put(() -> {
-            try {
-                GameObject g = new GameObject(0,0);
-                GameObject gg = new GameObject(1,1);
-                if(g.collidesWith(gg)){
-                    return GameTestCtx.ok;
-                } else {
-                    return new ErrMsg("Doesnt collide");
-                }
-            } catch (Exception e) {
-                return e;
-            }
-        });
-        Throwable ex = GameTestCtx.returnQueue.take();
-        assertEquals("Did it work?", ex, GameTestCtx.ok);
-    }*/
-    
-    /*@Test
-    public void gameObjectCollidesAnyTest() throws InterruptedException {
-        // NOTE to Timo: Do NOT use assertions inside the () -> { test }! Only catch errors and return them.
-        GameTestCtx.inputQueue.put(() -> {
-            try {
-                GameObject g = new GameObject(0,0);
-                GameObject gg = new GameObject(1,1);
-                Projectile p = new Projectile(15,15,"src/assets/spr_item_crest.png",3);
-                ArrayList<GameObject> list = new ArrayList<GameObject>();
-                list.add(gg);
-                list.add(p);
-                if(g.collidesAny(list)!=null){
-                    return GameTestCtx.ok;
-                } else {
-                    return new ErrMsg("Doesn't collide with anything");
-                }
-            } catch (Exception e) {
-                return e;
-            }
-        });
-        Throwable ex = GameTestCtx.returnQueue.take();
-        assertEquals("Did it work?", ex, GameTestCtx.ok);
-    }*/
-    
-    /*@Test
-    public void playerShootTest() throws InterruptedException {
-        // NOTE to Timo: Do NOT use assertions inside the () -> { test }! Only catch errors and return them.
-        GameTestCtx.inputQueue.put(() -> {
-            try {
-                Input i = new Input(480);
-                Player p = new Player(0,0,"src/assets/spr_item_crest.png",5,i);
-                p.setTryShoot(true);
-                if (p.shoot(2) != null) {
-                    return GameTestCtx.ok;
-                } else {
-                    return new ErrMsg("Nothing shot");
-                }
-                
-            } catch (Exception e) {
-                return e;
-            }
-        });
-        Throwable ex = GameTestCtx.returnQueue.take();
-        assertEquals("Did it work?", ex, GameTestCtx.ok);
-    }*/
-    
-    
-    
-
 }

--- a/bitz/src/test/java/bitzgame/bitz/MainTest.java
+++ b/bitz/src/test/java/bitzgame/bitz/MainTest.java
@@ -39,8 +39,7 @@ public class MainTest {
     public void imageTest() {
         Throwable result = gameLoop.runInLoop(() -> {
             Image test = new Image("src/assets/spr_item_crest.png");
-            return new OkResult();
         });
-        assertEquals("Did it work?", new OkResult(), result);
+        assertEquals("Did it work?", gameLoop.ok, result);
     }
 }


### PR DESCRIPTION
Some tidbits:
- I excluded `Main` from the PIT tests. This is because it's difficult to test – the `GameTestCtx` replaces `Main` when testing, so we can't test `Main` itself easily. That's why it's a good idea to refactor almost any functionality outside of `Main`.
- Turns out Slick2D supports only running one game loop / game window at a time. The PIT tests were failing because of this: the new mutations tried to start new game loops, and this caused crashes. `GameTestCtx` now inits the game loop globally only once, and after that, only returns a reference to it.
- API change: OkResult now supports `.equals()` method, you can just keep creating them with `new OkResult()`, and they still equal to each other.
- API change: `GameLoopCtx` now has the method `runInLoop` that takes a closure and spits out the result, so you don't have to manually use the `BlockingQueues` to pass the tests to the game loop.
- API change: we don't tear down the game loop anymore (the reason explained above) so the tear down methods were removed.
- I tested that PIT really works: the report, for example, suggested that the tests don't test the case when `GameObject.renderable()` is passed a `null` instead of a proper `Camera` object. I implemented a test (`gameObjectRenderableTest2`) to test this case. After running PIT again, the report says that this case is covered.
